### PR TITLE
Fixes output directory error, I think.

### DIFF
--- a/bamliquidator_batch.py
+++ b/bamliquidator_batch.py
@@ -101,7 +101,11 @@ class BaseLiquidator(object):
         if not os.path.isfile(self.executable_path):
             exit("%s is missing -- try cd'ing into the directory and running 'make'" % self.executable_path)
 
-        os.mkdir(output_directory)
+        try:
+            print("Making output directory: %s" % (output_directory))
+            os.mkdir(output_directory)
+        except OSError:
+            print("\tOutput directory already existed. Continuing anyway.")
 
         if self.counts_file_path is None:
             self.counts_file_path = os.path.join(output_directory, "counts.h5")


### PR DESCRIPTION
MAKING TSS COLLECTION
MAKING ENHANCER ASSOCIATED GENE TSS COLLECTION
MAPPING SIGNAL AT ENHANCER ASSOCIATED GENE TSS
Mapping rankby bam ../sshfs/4_dedupe/CONV4_CD4.nomito.rmdup.bam
python bamliquidator_batch.py --sense . -e 200 --match_bamToGFF -r ../sshfs/x_rose/CONV4_CD4/mm9_TSS_ENHANCER_GENES_-5000_+5000.gff -o ../sshfs/x_rose/CONV4_CD4/mm9_TSS_ENHANCER_GENES_-5000_+5000_CONV4_CD4.nomito.rmdup.bam/ ../sshfs/4_dedupe/CONV4_CD4.nomito.rmdup.bam
Traceback (most recent call last):
  File "bamliquidator_batch.py", line 343, in <module>
    main()
  File "bamliquidator_batch.py", line 326, in main
    liquidator = RegionLiquidator(args.regions_file, args.output_directory, args.bam_file_path, args.counts_file)
  File "bamliquidator_batch.py", line 214, in **init**
    super(RegionLiquidator, self).**init**("bamliquidator_regions", "region_counts", output_directory, bam_file_path, counts_file_path)
  File "bamliquidator_batch.py", line 104, in **init**
    os.mkdir(output_directory)
OSError: [Errno 17] File exists: '../sshfs/x_rose/CONV4_CD4/mm9_TSS_ENHANCER_GENES_-5000_+5000_CONV4_CD4.nomito.rmdup.bam/'
ERROR: FAILED TO MAP ../sshfs/x_rose/CONV4_CD4/mm9_TSS_ENHANCER_GENES_-5000_+5000.gff FROM BAM: ../sshfs/4_dedupe/CONV4_CD4.nomito.rmdup.bam
{'control': '', 'geneList': None, 'rankby': '../sshfs/4_dedupe/CONV4_CD4.nomito.rmdup.bam', 'window': 50000, 'genome': 'mm9', 'input': '../sshfs/x_rose/CONV4_CD4/CONV4_CD4_SuperStretchEnhancers.table.txt', 'formatTable': False, 'out': None}
USING mm9 AS THE GENOME
MAKING TRANSCRIPT COLLECTION
