### PR TITLE
bamliquidator_batch now compatible with latest bokeh version

### DIFF
--- a/bamliquidator_internal/bamliquidatorbatch/bamliquidator_batch.py
+++ b/bamliquidator_internal/bamliquidatorbatch/bamliquidator_batch.py
@@ -20,7 +20,7 @@ from time import time
 from os.path import basename
 from os.path import dirname
 
-__version__ = '1.2.0'
+__version__ = '1.3.0'
 
 default_black_list = ["chrUn", "_random", "Zv9_", "_hap"]
 


### PR DESCRIPTION
bamliquidator_batch was originally developed for bokeh 0.4.  latest
version is 0.9 and has some breaking changes.  for a while we held off
upgrading due to some performance problems with bokeh 0.5, but latest
version has good performance and 0.4 is too old to keep trying to use.

resolves #26
fixes one of the errors in #49