### PR TITLE
Correct binsize calculation

### DIFF
--- a/bamliquidator_internal/bamliquidator.cpp
+++ b/bamliquidator_internal/bamliquidator.cpp
@@ -198,11 +198,13 @@ std::vector<double> liquidate(const samfile_t* fp, const bam_index_t* bamidx,
   only deal with coord, so use generic item
   */
   int startArr[spnum], stopArr[spnum];
-  int pieceLength = (stop-start) / spnum;
+	
+   // gff has fully closed intervals thus the length needs +1
+  int pieceLength = (stop-start+1) / spnum;
   for(int i=0; i<spnum; i++)
   {
-    startArr[i] = start + pieceLength*i;
-    stopArr[i] = start + pieceLength*(i+1);
+    startArr[i] = start + pieceLength*i; 
+    stopArr[i] = startArr[i] + pieceLength -1;
   }
 
   std::deque<ReadItem> items = bamQuery_region(fp,bamidx,coord,strand,extendlen);


### PR DESCRIPTION
Binsize calculation is based on the gff input file and thus needs to add 1 for the region size. Since this was missing
an offset error accumulated with the number of bins used and the end of a region was never been used for calculation.
E.g. A region with 60 bins would lack the last 60bp of a region due to the offset error accumulation.